### PR TITLE
Update Minecraft wiki links to new domain

### DIFF
--- a/doc/Sky.md
+++ b/doc/Sky.md
@@ -28,9 +28,9 @@
 
 Resources:
 
-- https://minecraft.fandom.com/wiki/Cloud
-- https://minecraft.fandom.com/wiki/Daylight_cycle
-- https://minecraft.fandom.com/wiki/Effect_(dimension)
+- https://minecraft.wiki/w/Cloud
+- https://minecraft.wiki/w/Daylight_cycle
+- https://minecraft.wiki/w/Effect_(dimension)
 
 ## Tasks
 

--- a/src/main/java/de/bixilon/minosoft/commands/parser/minecraft/target/targets/selector/properties/EntityTargetProperties.kt
+++ b/src/main/java/de/bixilon/minosoft/commands/parser/minecraft/target/targets/selector/properties/EntityTargetProperties.kt
@@ -21,7 +21,7 @@ import de.bixilon.minosoft.commands.parser.minecraft.target.targets.selector.pro
 import de.bixilon.minosoft.commands.parser.minecraft.target.targets.selector.properties.rotation.YawRotation
 import de.bixilon.minosoft.commands.parser.minecraft.target.targets.selector.properties.sort.SortProperty
 
-// See https://minecraft.fandom.com/wiki/Target_selectors
+// See https://minecraft.wiki/w/Target_selectors
 object EntityTargetProperties {
     val properties: MutableMap<String, EntityTargetPropertyFactory<*>> = mutableMapOf()
 

--- a/src/main/java/de/bixilon/minosoft/data/registries/identified/ResourceLocation.kt
+++ b/src/main/java/de/bixilon/minosoft/data/registries/identified/ResourceLocation.kt
@@ -26,7 +26,7 @@ import java.util.*
  *
  * @throws IllegalArgumentException If the namespace or path does not match the allowed pattern. and [ALLOWED_PATH_PATTERN]
  *
- * @see <a href="https://minecraft.fandom.com/wiki/Resource_location">Resource location</a>
+ * @see <a href="https://minecraft.wiki/w/Resource_location">Resource location</a>
  */
 open class ResourceLocation(
     val namespace: String = Namespaces.DEFAULT,

--- a/src/main/java/de/bixilon/minosoft/data/world/time/MoonPhases.kt
+++ b/src/main/java/de/bixilon/minosoft/data/world/time/MoonPhases.kt
@@ -16,7 +16,7 @@ package de.bixilon.minosoft.data.world.time
 import de.bixilon.kutil.enums.EnumUtil
 import de.bixilon.kutil.enums.ValuesEnum
 
-// see https://minecraft.fandom.com/wiki/Moon
+// see https://minecraft.wiki/w/Moon
 enum class MoonPhases(val light: Float) {
     FULL_MOON(1.0f),
     WANING_GIBBOUS(0.7f),

--- a/src/main/java/de/bixilon/minosoft/input/interaction/breaking/survival/SurvivalDigger.kt
+++ b/src/main/java/de/bixilon/minosoft/input/interaction/breaking/survival/SurvivalDigger.kt
@@ -56,7 +56,7 @@ class SurvivalDigger(
         breaking.interactions.swingHand(Hands.MAIN)
     }
 
-    // thanks to https://minecraft.fandom.com/wiki/Breaking#Calculation
+    // thanks to https://minecraft.wiki/w/Breaking#Calculation
     private fun tick(status: BlockDigStatus?, target: BlockTarget, slot: Int) {
         val stack = connection.player.items.inventory.getHotbarSlot()
 


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.